### PR TITLE
Fixed incorrect rendering of color pickers and blur on safari.

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -44,17 +44,20 @@ body {
 .theme--dark.v-app-bar.v-toolbar.v-sheet {
     background-color: rgba(0, 0, 0, 0.32)!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 .theme--dark.v-navigation-drawer,
 .v-color-picker__controls {
     background: rgba(0, 0, 0, 0.32);
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 .v-application .panel {
     background-color: rgba(0, 0, 0, 0.48)!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     box-shadow: none!important;
     border: none;
 }
@@ -101,6 +104,7 @@ body {
 .echarts-tooltip {
     background-color: rgba(0, 0, 0, 0.43)!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     border: none!important;
     box-shadow: none!important;
 }
@@ -109,10 +113,11 @@ body {
     border-radius: 15px;
     background-color: rgba(0, 0, 0, 0.85)!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 .v-application .grey.darken-3.v-btn,
-.v-btn,
+.v-btn:not(.warning):not([data-v-029e4e5c]):not(._btn-extruder-cmd):not([style]),
 .v-btn-toggle {
     box-shadow: none!important;
     background-color: transparent !important;
@@ -137,6 +142,7 @@ body {
     right: 6px!important;
     background-color: rgba(0, 0, 0, 0.33)!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     border-radius: 8px;
     border-top-left-radius: 8px;
     margin-bottom: 10px
@@ -173,6 +179,7 @@ x-vue-echarts text{
 .fluidd .v-expansion-panel{
     background-color: rgba(0, 0, 0, 0.24)!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     border: none!important;
     box-shadow: none!important;
     border-radius: 15px;
@@ -182,12 +189,14 @@ x-vue-echarts text{
 .fluidd .console-wrapper {
     background-color: transparent!important;
     backdrop-filter: none;
+    -webkit-backdrop-filter: none;
 }
 
 .fluidd .file-system .v-toolbar,
 .fluidd .footer {
     background-color: transparent!important;
     backdrop-filter: none!important;
+    -webkit-backdrop-filter: none!important;
 }
 
 .fluidd .console-wrapper .secondary--text,
@@ -222,6 +231,7 @@ x-vue-echarts text{
     background-color: rgb(0 0 0 /12%)!important;
     border: none!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 .fluidd .v-navigation-drawer .v-list-item--active {
@@ -241,6 +251,7 @@ x-vue-echarts text{
     background-color: rgb(0 0 0 / 15%)!important;
     border-radius: 15px!important;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 .fluidd .v-data-table>.v-data-table__wrapper tbody tr:hover td:first-child {


### PR DESCRIPTION
The last few months I've been making my fork of your theme. These are the issues I have noticed and managed to solve. Here are screenshots that show the difference:

_Before_
<img width="1542" height="895" alt="Screenshot 2025-11-30 at 8 34 56 PM" src="https://github.com/user-attachments/assets/ac2dd138-1fb8-4c0e-891b-2700c98d601d" />
_After_
<img width="1542" height="895" alt="Screenshot 2025-11-30 at 8 35 38 PM" src="https://github.com/user-attachments/assets/66fe1dfb-4619-4cc1-b6f3-d31f63e9351e" />
